### PR TITLE
hotfix: unclosed a on index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,6 @@
         </li>
       </ol>
     </main>
-    <footer><a href="HOW_TO_REVIEW.md">HOW TO REVIEW MD</footer>
+    <footer><a href="HOW_TO_REVIEW.md">HOW TO REVIEW MD</a></footer>
   </body>
 </html>


### PR DESCRIPTION
It's my vscode eating my tags again

@illicitonion the lighthouse is running on the index.html. We will have to deploy each folder separately to get it to run on both projects, annoyingly.

The 93% is an unclosed a which has crept in somewhere. My VScode sometimes eats tags like this - it's annoying. 